### PR TITLE
fix(gulp/build.js): fix bug for builing js files

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -40,7 +40,7 @@ exports.vendor = function(gulp, plugins) {
 
 exports.client = function(gulp, plugins) {
     return function() {
-        var development = process.env.NODE_ENV === 'development';
+        var isDevelopment = process.env.NODE_ENV !== 'production';
         var buildDir = path.join(__dirname, '../build');
         var stream;
 
@@ -59,7 +59,7 @@ exports.client = function(gulp, plugins) {
                 libs.forEach(function(lib) {bundler.external(lib); });
             });
 
-        if (development) {
+        if (isDevelopment) {
             stream = stream
                 .pipe(transform(function() {return mold.transformSourcesRelativeTo(path.join(__dirname, '../')); }))
                 .pipe(transform(function() {return exorcist('./build/' + buildname + '.js.map'); }))


### PR DESCRIPTION
자바스크립트 파일 빌드 할때 개발환경인 경우 if 조건이 안맞아 빌드 후 압축되지 않은 자바스크립트가 없어서 index.html을 실행해도 자바스크립트를 불러 오지 못하는 버그를 발견 하였습니다. 초보자들은 이것을 모르고 안되는 프로젝트로 인식할까 하여 수정된 버전 풀리퀘스트 보냅니다~~